### PR TITLE
temp fix to specs

### DIFF
--- a/Specifications/Store/Specs/when_committing_event_streams/when_a_commit_is_persisited.cs
+++ b/Specifications/Store/Specs/when_committing_event_streams/when_a_commit_is_persisited.cs
@@ -34,6 +34,7 @@ namespace Dolittle.Runtime.Events.Store.Specs.when_committing_event_streams
         };
         It should_have_the_correct_versioned_event_source = () => committed_events.Source.ShouldEqual(uncommitted_events.Source);
         It should_have_a_sequence_id = () => committed_events.Sequence.ShouldEqual(new CommitSequenceNumber(1));
+        
         Cleanup nh = () => event_store.Dispose();
     }
 }

--- a/Specifications/Store/Specs/when_committing_event_streams/when_another_commit_is_persisited_for_the_same_event_source.cs
+++ b/Specifications/Store/Specs/when_committing_event_streams/when_another_commit_is_persisited_for_the_same_event_source.cs
@@ -38,6 +38,7 @@ namespace Dolittle.Runtime.Events.Store.Specs.when_committing_event_streams
         It should_have_the_correct_versioned_event_source = () => committed_events.Source.ShouldEqual(uncommitted_events.Source);
 
         It should_have_a_sequence_id_for_the_second_commit = () => committed_events.Sequence.ShouldEqual(new CommitSequenceNumber(2));
+        
         Cleanup nh = () => event_store.Dispose();
     }
 }

--- a/Specifications/Store/Specs/when_committing_event_streams/when_committing_a_duplicate_commit.cs
+++ b/Specifications/Store/Specs/when_committing_event_streams/when_committing_a_duplicate_commit.cs
@@ -24,5 +24,7 @@ namespace Dolittle.Runtime.Events.Store.Specs.when_committing_event_streams
         Because of = () => event_store._do((es) => exception = Catch.Exception(() => es.Commit(uncommitted_events)));
 
         It fails_as_the_commit_is_a_duplicate = () => exception.ShouldBeOfExactType<CommitIsADuplicate>();
+
+        Cleanup nh = () => event_store.Dispose();
     }
 }

--- a/Specifications/Store/Specs/when_committing_event_streams/when_committing_a_version_that_conflicts_with_an_existing_commit.cs
+++ b/Specifications/Store/Specs/when_committing_event_streams/when_committing_a_version_that_conflicts_with_an_existing_commit.cs
@@ -27,5 +27,7 @@ namespace Dolittle.Runtime.Events.Store.Specs.when_committing_event_streams
         Because of = () => event_store._do((es) => exception = Catch.Exception(() => es.Commit(conflicting_uncommitted_events)));
 
         It fails_as_the_commit_has_a_concurrency_conflict = () => exception.ShouldBeOfExactType<EventSourceConcurrencyConflict>();
+        
+        Cleanup nh = () => event_store.Dispose();
     }
 }

--- a/Specifications/Store/Specs/when_committing_event_streams/when_committing_a_version_that_is_ahead_of_the_next_expected_version.cs
+++ b/Specifications/Store/Specs/when_committing_event_streams/when_committing_a_version_that_is_ahead_of_the_next_expected_version.cs
@@ -38,6 +38,7 @@ namespace Dolittle.Runtime.Events.Store.Specs.when_committing_event_streams
         };
         It should_have_the_correct_versioned_event_source = () => committed_events.Source.ShouldEqual(ahead_uncommitted_events.Source);
         It should_have_a_sequence_id = () => committed_events.Sequence.ShouldEqual(new CommitSequenceNumber(1));
+        
         Cleanup nh = () => event_store.Dispose();
     }
 }

--- a/Specifications/Store/Specs/when_committing_event_streams/when_committing_a_version_that_is_behind_the_existing_version.cs
+++ b/Specifications/Store/Specs/when_committing_event_streams/when_committing_a_version_that_is_behind_the_existing_version.cs
@@ -28,5 +28,7 @@ namespace Dolittle.Runtime.Events.Store.Specs.when_committing_event_streams
         Because of = () => event_store._do((es) => exception = Catch.Exception(() => es.Commit(behind_uncommitted_events)));
 
         It fails_as_the_commit_has_a_concurrency_conflict = () => exception.ShouldBeOfExactType<EventSourceConcurrencyConflict>();
+        
+        Cleanup nh = () => event_store.Dispose();
     }
 }


### PR DESCRIPTION
I think the AppVeyor build is failing because of lack of cleanup code on some of the specs.

I've changed this directly in here, not in the submodule.  This isn't set up correctly at the moment, but my big tidy-up refactoring sets up the submodule correctly in the new Specifications/Store/Specs folder.